### PR TITLE
Update DoorManager.psc

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
+++ b/Scripts/Source/User/WorkshopFramework/Quests/DoorManager.psc
@@ -479,7 +479,7 @@ Function RegisterAllDoors(WorkshopScript akWorkshopRef)
 			i = 0
 			iCount = DisabledDoors.GetCount()
 			while(i < iCount)
-				ObjectReference thisDoor = FoundDoors.GetAt(i)
+				ObjectReference thisDoor = DisabledDoors.GetAt(i)
 				if(thisDoor != None && thisDoor.IsDeleted())
 					UnregisterDoor(thisDoor)
 				endif


### PR DESCRIPTION
L482 is referencing the wrong RefColectionAlias.

This causes a lot of chatter in the Papyrus.log