### PR TITLE
Add none check to ClearInWorkshopModeFlags

### DIFF
--- a/Scripts/Source/User/WorkshopFramework/MainQuest.psc
+++ b/Scripts/Source/User/WorkshopFramework/MainQuest.psc
@@ -399,7 +399,10 @@ Function ClearInWorkshopModeFlags()
 	WorkshopScript[] Workshops = WorkshopParent.Workshops
 	int i = 0
 	while(i < Workshops.Length)
-		Workshops[i].UFO4P_InWorkshopMode = false
+		if ( Workshops[i] != none )
+			Workshops[i].UFO4P_InWorkshopMode = false
+		endif
+		
 		i += 1
 	endwhile
 EndFunction


### PR DESCRIPTION
Add none check to `ClearInWorkshopModeFlags` in MainQuest script.

On a new game start this function is called before WorkshopParent has completed init. This litters the Papyrus.log file with errors.
```
error: Cannot call UFO4P_InWorkshopMode() on a None object, aborting function call
stack:
	[WSFW_Main (0B000F99)].workshopframework:mainquest.ClearInWorkshopModeFlags() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4\Data\Scripts\Source\User\WorkshopFramework\MainQuest.psc" Line 402
	[WSFW_Main (0B000F99)].workshopframework:mainquest.HandleGameLoaded() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4\Data\Scripts\Source\User\WorkshopFramework\MainQuest.psc" Line 333
	[WSFW_Main (0B000F99)].workshopframework:mainquest.GameLoaded() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4\Data\Scripts\Source\User\WorkshopFramework\Library\ControllerQuest.psc" Line 65
	[WSFW_Main (0B000F99)].workshopframework:mainquest.OnQuestInit() - "C:\Program Files (x86)\Steam\steamapps\common\Fallout 4\Data\Scripts\Source\User\WorkshopFramework\Library\ControllerQuest.psc" Line 50
```